### PR TITLE
fix: 카카오 로그인 취소 시 버튼 disable 안 풀리는 문제 수정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -105,6 +105,17 @@ const App = () => {
             )} })); true;`,
           );
           console.error('[KakaoLogin] injectJavaScript called');
+        } catch (e) {
+          console.error('[KakaoLogin] login() failed or cancelled:', e);
+          const errorPayload = JSON.stringify({
+            type: 'KAKAO_LOGIN_ERROR',
+            payload: { message: String(e) },
+          });
+          ref.current?.injectJavaScript(
+            `window.dispatchEvent(new MessageEvent('message', { data: ${JSON.stringify(
+              errorPayload,
+            )} })); true;`,
+          );
         } finally {
           kakaoLoginInFlight.current = false;
         }


### PR DESCRIPTION
## Summary
- 카카오 네이티브 로그인 도중 사용자가 취소하거나 `login()`이 실패하면, RN에서 웹으로 아무 메시지도 보내지 않아 웹의 `isRequesting`이 계속 `true`로 남아 로그인 버튼이 dimmed(disabled) 상태로 고정되는 문제가 있었습니다.
- `KAKAO_LOGIN` 처리에 `catch` 블록을 추가해, 실패/취소 시 `{ type: 'KAKAO_LOGIN_ERROR', payload: { message } }`를 웹에 `postMessage`(dispatchEvent)로 전달하도록 수정했습니다.

## Note
- 웹(forgather-frontend-web-v3) 쪽에서 `KAKAO_LOGIN_ERROR` 메시지를 받아 `isRequesting`을 `false`로 리셋하는 처리가 별도로 필요합니다 (웹 담당자가 직접 작업 예정).

## Test plan
- [x] `npx tsc --noEmit` 통과
- [ ] 웹 쪽 `KAKAO_LOGIN_ERROR` 리스너 추가 후, 카카오 로그인 취소 시 버튼이 다시 활성화되는지 실기기/시뮬레이터 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)