### PR TITLE
iOS 웹뷰 스와이프 뒤로가기 제스처 활성화

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -386,6 +386,7 @@ const App = () => {
           startInLoadingState
           setSupportMultipleWindows={false}
           pullToRefreshEnabled={Platform.OS === 'android'}
+          allowsBackForwardNavigationGestures={Platform.OS === 'ios'}
           onNavigationStateChange={s => setCanGoBack(s.canGoBack)}
           onShouldStartLoadWithRequest={onShouldStart}
           onMessage={onMessage}


### PR DESCRIPTION
## Summary
- WebView에 `allowsBackForwardNavigationGestures={Platform.OS === 'ios'}` 추가
- iOS에서 화면 가장자리 스와이프로 뒤로가기 가능

## Test plan
- [ ] iOS 시뮬레이터/기기에서 페이지 이동 후 왼쪽 가장자리 스와이프로 뒤로가기 동작 확인
- [ ] Android는 기존 하드웨어 뒤로가기 버튼 동작에 영향 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)