### PR TITLE
feature: Universal Links / App Links 딥링크 지원

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -41,6 +41,17 @@ const allowedHost = (host: string) =>
     h => host === h || host.endsWith(`.${h}`),
   );
 
+const isOurWebUrl = (host: string) =>
+  MY_DOMAINS.some(h => host === h || host.endsWith(`.${h}`));
+
+const toWebViewTarget = (url: string) => {
+  if (!/^https?:\/\//i.test(url)) {
+    return null;
+  }
+  const host = url.split('/')[2]?.split(':')[0] || '';
+  return isOurWebUrl(host) ? url : null;
+};
+
 type SaveImagePayload = { url: string; filename?: string };
 
 const guessImageExtension = ({ filename, url }: SaveImagePayload) => {
@@ -97,7 +108,23 @@ const saveImageToDevice = async ({ url, filename }: SaveImagePayload) => {
 const App = () => {
   const ref = useRef<WebView>(null);
   const [canGoBack, setCanGoBack] = useState(false);
+  const [sourceUri, setSourceUri] = useState(WEB_URL);
   const kakaoLoginInFlight = useRef(false);
+
+  useEffect(() => {
+    const handleIncomingUrl = (url: string | null) => {
+      const target = url && toWebViewTarget(url);
+      if (target) {
+        setSourceUri(target);
+      }
+    };
+
+    Linking.getInitialURL().then(handleIncomingUrl);
+    const sub = Linking.addEventListener('url', ({ url }) =>
+      handleIncomingUrl(url),
+    );
+    return () => sub.remove();
+  }, []);
 
   useEffect(() => {
     const sub = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -376,7 +403,7 @@ const App = () => {
       <SafeAreaView style={{ flex: 1 }}>
         <WebView
           ref={ref}
-          source={{ uri: WEB_URL }}
+          source={{ uri: sourceUri }}
           renderLoading={() => <ActivityIndicator size="large" />}
           domStorageEnabled
           javaScriptEnabled

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,13 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
+        <intent-filter android:autoVerify="true">
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" android:host="forgather.app" />
+            <data android:scheme="https" android:host="dev.forgather.app" />
+        </intent-filter>
       </activity>
       <activity
         android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"

--- a/ios/forgatherApp/forgatherApp.entitlements
+++ b/ios/forgatherApp/forgatherApp.entitlements
@@ -6,5 +6,10 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:forgather.app</string>
+		<string>applinks:dev.forgather.app</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Android `MainActivity`에 `autoVerify` intent-filter를 추가해 `https://forgather.app`, `https://dev.forgather.app`를 App Links로 등록
- iOS entitlements에 `applinks:forgather.app`, `applinks:dev.forgather.app`를 등록해 Universal Links 지원
- 앱이 콜드/웜 스타트로 해당 URL을 통해 열릴 경우, `Linking.getInitialURL` / `Linking.addEventListener('url', ...)`로 URL을 받아 우리 도메인인지 검증(`isOurWebUrl`/`toWebViewTarget`) 후 WebView가 해당 경로를 바로 로드하도록 `sourceUri` state로 전환

## Test plan
- [ ] Android: `adb shell am start -a android.intent.action.VIEW -d "https://dev.forgather.app/..."` 로 App Links 진입 시 해당 경로가 WebView에 로드되는지 확인
- [ ] Android: `assetlinks.json`이 `https://forgather.app/.well-known/assetlinks.json`, `https://dev.forgather.app/.well-known/assetlinks.json`에 배포되어 있는지 확인 (없으면 autoVerify 실패)
- [ ] iOS: Universal Link로 앱 실행 시 해당 경로가 WebView에 로드되는지 확인
- [ ] iOS: `apple-app-site-association` 파일이 서버에 배포되어 있는지 확인
- [ ] 콜드 스타트/웜 스타트(백그라운드 상태에서 링크 클릭) 둘 다 확인
- [ ] 우리 도메인이 아닌 URL은 무시되고 기본 `WEB_URL`로 열리는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)