### PR TITLE
fix: 애플 로그인 한국어 이름 성/이름 순서 보정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -34,12 +34,24 @@ const DEFAULT_SHARE_IMAGE_URL = 'https://dysvfn6jyq7o7.cloudfront.net/images/og-
 
 const APPLE_FULL_NAME_STORAGE_KEY = 'appleFullName';
 
+// 애플이 내려주는 fullName이 한글(성이 이름보다 앞에 오는 표기) 이름인지 판별
+const isKoreanFullName = (value: string) => /[가-힣]/.test(value);
+
 const formatFullName = (
   fullName: { givenName?: string | null; familyName?: string | null } | null,
 ) => {
   if (!fullName) return null;
-  const parts = [fullName.givenName, fullName.familyName].filter(Boolean);
-  return parts.length ? parts.join(' ') : null;
+  const { givenName, familyName } = fullName;
+  const nameParts = [givenName, familyName].filter(Boolean);
+  if (!nameParts.length) return null;
+
+  // 한국어 이름은 "성+이름"을 띄어쓰기 없이 이어붙임 (예: 홍길동)
+  if (isKoreanFullName(nameParts.join(''))) {
+    return [familyName, givenName].filter(Boolean).join('');
+  }
+
+  // 그 외(영어 등)는 기존과 동일하게 "이름 성" 순서 유지
+  return nameParts.join(' ');
 };
 
 const MY_DOMAINS = ['dev.forgather.app', 'forgather.app', 'localhost'];


### PR DESCRIPTION
## 배경
forgather-frontend-web-v3 [#211](https://github.com/forgather-app/forgather-frontend-web-v3/issues/211)

애플 로그인 시 `PersonNameComponents`(`givenName`, `familyName`)를 조합해 만드는 `full_name`이 한국어 이름에서도 항상 `givenName + familyName` 순서로 고정되어 있어, 성과 이름이 뒤바뀐 채(예: "길동 홍") 웹뷰로 전달되던 버그를 수정합니다.

## 변경 사항
- [App.tsx](App.tsx) `formatFullName`
  - fullName에 한글이 포함되어 있으면 `familyName + givenName`을 공백 없이 조합 (예: 홍길동)
  - 그 외(영어 등)는 기존과 동일하게 `givenName + familyName` 순서 유지

## 테스트
- [ ] 실기기(iOS)에서 애플 로그인 최초 동의 플로우로 재현 테스트 필요 (자동 테스트 스크립트 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)