### PR TITLE
fix: 작품 영상(유튜브 임베드)이 외부 브라우저로 열리는 문제 수정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -195,15 +195,11 @@ const App = () => {
       return false; // 외부 열기 금지
     }
 
-    if (
-      Platform.OS === 'ios' &&
-      req.navigationType === 'click' &&
-      !req.isTopFrame
-    ) {
-      ref.current?.injectJavaScript(
-        `window.location.href=${JSON.stringify(url)}; true;`,
-      );
-      return false;
+    // 최상위 프레임이 아닌 요청(iframe 로드 및 iframe 내부 네비게이션)은 항상
+    // WebView 안에서 처리한다. 유튜브 임베드 같은 서드파티 iframe을 외부로
+    // 내보내면 임베드 플레이어가 top-level 문서로 열려 재생이 깨진다(Error 153).
+    if (req.isTopFrame === false) {
+      return true;
     }
 
     try {

--- a/ios/forgatherApp.xcodeproj/project.pbxproj
+++ b/ios/forgatherApp.xcodeproj/project.pbxproj
@@ -272,7 +272,7 @@
 				CODE_SIGN_ENTITLEMENTS = forgatherApp/forgatherApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 3C38YUT7MY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = forgatherApp/Info.plist;
@@ -305,7 +305,7 @@
 				CODE_SIGN_ENTITLEMENTS = forgatherApp/forgatherApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 9;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 3C38YUT7MY;
 				INFOPLIST_FILE = forgatherApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;


### PR DESCRIPTION
## 변경사항 요약

- `onShouldStartLoadWithRequest`에서 최상위 프레임이 아닌 요청(iframe 로드·iframe 내부 네비게이션)은 항상 WebView 내부에서 처리하도록 변경
- 유튜브 임베드 iframe이 허용 호스트 목록에 없어 `Linking.openURL`로 외부에 넘겨지던 경로 제거
- iOS 전용 `click && !isTopFrame → 최상위 이동` 분기 제거 (위 변경으로 불필요)

## 배경

- 작품 상세의 유튜브 영상이 iframe 안에서 재생되지 않고, 유튜브 앱이 실행되거나 인앱 브라우저에 `Error 153`(임베드 플레이어가 top-level 문서로 로드됨)이 표시됨
- 원인은 앱이 iframe 요청을 외부 링크로 취급해 밖으로 내보낸 것

## 테스트

- `npx tsc --noEmit` 통과 (기존 crypto-js 타입 경고 외 에러 없음)
- `npx eslint App.tsx` 통과
- 실기기에서 영상 포함 작품 상세 진입 시 iframe 내 재생 확인 필요

## 스크린샷

<!-- 실기기 확인 후 첨부 -->